### PR TITLE
Fix list divider height is not considered in calculating scrollY

### DIFF
--- a/src/com/larswerkman/quickreturnlistview/QuickReturnListView.java
+++ b/src/com/larswerkman/quickreturnlistview/QuickReturnListView.java
@@ -46,13 +46,14 @@ public class QuickReturnListView extends ListView {
 		if (mItemOffsetY == null) {
 			mItemOffsetY = new int[mItemCount];
 		}
+		int dividerHeight = getDividerHeight();
 		for (int i = 0; i < mItemCount; ++i) {
 			View view = getAdapter().getView(i, null, this);
 			view.measure(
 					MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED),
 					MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED));
 			mItemOffsetY[i] = mHeight;
-			mHeight += view.getMeasuredHeight();
+			mHeight += view.getMeasuredHeight() + dividerHeight;
 			System.out.println(mHeight);
 		}
 		scrollIsComputed = true;


### PR DESCRIPTION
The `mItemOffsetY` is calculated incorrectly when ListView is set with divider as below:

``` xml
<com.larswerkman.quickreturnlistview.QuickReturnListView
        android:id="@android:id/list"
        android:layout_width="match_parent"
        android:layout_height="wrap_content"
        android:divider="#abcdef"
        android:dividerHeight="1dp" />
```

Here's a quick fix for the issue.
